### PR TITLE
Fix update function to delete policies

### DIFF
--- a/Core/Executor/RoleManager.php
+++ b/Core/Executor/RoleManager.php
@@ -106,7 +106,7 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
 
                 // Removing all policies so we can add them back.
                 // TODO: Check and update policies instead of remove and add.
-                $policies = $role->getPolicies();
+                $policies = $roleDraft->getPolicies();
                 foreach ($policies as $policy) {
                     $roleService->removePolicyByRoleDraft($roleDraft, $policy);
                 }
@@ -440,7 +440,7 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
         }
 
         $roleService->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
-        
+
         if (is_callable(array($roleService, 'publishRoleDraft'))) {
             $roleService->publishRoleDraft($roleDraft);
         }


### PR DESCRIPTION
The bug occurs when running migration to update role. When it attempts to delete all policies, it will load related objects of class `Policy` and attempt delete them by calling 
```php
$roleService->removePolicyByRoleDraft($roleDraft, $policy);
```
The second argument (`$policy`) is expected to be of class `PolicyDraft` and not `Policy`, thus an error occurs and so it fails to perform the migration.