### PR TITLE
Move up the publish of draft to prevent publishing draft without policies assigned

### DIFF
--- a/Core/Executor/RoleManager.php
+++ b/Core/Executor/RoleManager.php
@@ -111,6 +111,8 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
                     $roleService->removePolicyByRoleDraft($roleDraft, $policy);
                 }
 
+                $roleService->publishRoleDraft($roleDraft);
+
                 foreach ($ymlPolicies as $ymlPolicy) {
                     $this->addPolicy($role, $roleService, $ymlPolicy);
                 }
@@ -123,8 +125,6 @@ class RoleManager extends RepositoryExecutor implements MigrationGeneratorInterf
             if (isset($step->dsl['unassign'])) {
                 $this->unassignRole($role, $roleService, $userService, $step->dsl['unassign']);
             }
-
-            $roleService->publishRoleDraft($roleDraft);
 
             $roleCollection[$key] = $role;
         }


### PR DESCRIPTION
We noticed that running policy updates does not add policies. After more in-depth investigation discovered that the `update()` function published the version of role draft that did not have policies assigned. Moving the call to publish function up before adding policies seem to fix this problem for now. 

In the future, it would be nice to revise addPolicy() to not publish role draft on every new policy added. 