### PR TITLE
Fix public visibility for service on create command

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -807,6 +807,7 @@ services:
 
     ez_migration_bundle.helper.config.resolver:
         class: '%ez_migration_bundle.helper.config.resolver%'
+        public: true
         arguments:
             - '@ezpublish.config.resolver'
             - '@service_container'


### PR DESCRIPTION
Platform: Ibexa Open Source 3.2.8
Symfony Version: 5.1.11
PHP Version: 7.4.11

When I run this command: 

```
bin/console kaliop:migration:generate --type=role --mode=create --match-type=identifier --match-value=Customer MyBundle
```

I have this error:

```
In Container.php line 266:
                                                                                                                                                                                                                           
  The "ez_migration_bundle.helper.config.resolver" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependenc  
  y injection instead.                                                                                                                                                                                                     
                                                                                                                                                                                                                           

kaliop:migration:generate [--format FORMAT] [--type TYPE] [--mode MODE] [--match-type MATCH-TYPE] [--match-value MATCH-VALUE] [--match-except] [-l|--lang LANG] [--dbserver DBSERVER] [-a|--admin-login ADMIN-LOGIN] [--list-types] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> [<bundle> [<name>]]
```

This pulls request fixes the service `ez_migration_bundle.helper.config.resolver` visibility to solve this error.
